### PR TITLE
Support direct messages events api

### DIFF
--- a/twitter4j-appengine/src/main/java/twitter4j/LazyJSONImplFactory.java
+++ b/twitter4j-appengine/src/main/java/twitter4j/LazyJSONImplFactory.java
@@ -205,6 +205,11 @@ class LazyJSONImplFactory implements ObjectFactory {
     }
 
     @Override
+    public DirectMessageEventList createDirectMessageEventList(final HttpResponse res) throws TwitterException {
+        throw new TwitterException("Not Implemented");
+    }
+
+    @Override
     public Relationship createRelationship(HttpResponse res) throws TwitterException {
         return new LazyRelationship(res, factory);
     }

--- a/twitter4j-core/src/internal-json/java/twitter4j/DirectMessageEventJSONImpl.java
+++ b/twitter4j-core/src/internal-json/java/twitter4j/DirectMessageEventJSONImpl.java
@@ -27,10 +27,14 @@ import java.util.Date;
     /*package*/DirectMessageEventJSONImpl(HttpResponse res, Configuration conf) throws TwitterException {
         super(res);
         JSONObject json = res.asJSONObject();
-        init(json);
-        if (conf.isJSONStoreEnabled()) {
-            TwitterObjectFactory.clearThreadLocalMap();
-            TwitterObjectFactory.registerJSONObject(this, json);
+        try {
+            init(json.getJSONObject("event"));
+            if (conf.isJSONStoreEnabled()) {
+                TwitterObjectFactory.clearThreadLocalMap();
+                TwitterObjectFactory.registerJSONObject(this, json);
+            }
+        } catch (JSONException jsone) {
+            throw new TwitterException(jsone);
         }
     }
 
@@ -38,10 +42,9 @@ import java.util.Date;
         init(json);
     }
 
-    private void init(JSONObject json) throws TwitterException {
+    private void init(JSONObject event) throws TwitterException {
 
         try {
-            final JSONObject event = json.getJSONObject("event");
             type = ParseUtil.getUnescapedString("type", event);
             id = ParseUtil.getLong("id", event);
             createdTimestamp = new Date(event.getLong("created_timestamp"));

--- a/twitter4j-core/src/internal-json/java/twitter4j/DirectMessageEventListImpl.java
+++ b/twitter4j-core/src/internal-json/java/twitter4j/DirectMessageEventListImpl.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2007 Yusuke Yamamoto
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package twitter4j;
+
+/**
+ * @author Hiroaki TAKEUCHI - takke30 at gmail.com
+ * @since Twitter4J 4.0.7
+ */
+class DirectMessageEventListImpl extends ResponseListImpl<DirectMessageEvent> implements DirectMessageEventList {
+    private static final long serialVersionUID = 8150060768287194508L;
+    private final String nextCursor;
+
+    DirectMessageEventListImpl(RateLimitStatus rateLimitStatus, int accessLevel) {
+        super(rateLimitStatus, accessLevel);
+        nextCursor = null;
+    }
+
+    DirectMessageEventListImpl(int size, JSONObject json, HttpResponse res) {
+        super(size, res);
+        this.nextCursor = ParseUtil.getRawString("next_cursor", json);
+    }
+
+    @Override
+    public String getNextCursor() {
+        return nextCursor;
+    }
+
+}

--- a/twitter4j-core/src/internal-json/java/twitter4j/DirectMessageJSONImpl.java
+++ b/twitter4j-core/src/internal-json/java/twitter4j/DirectMessageJSONImpl.java
@@ -186,6 +186,33 @@ import java.util.Date;
         }
     }
 
+    /*package*/
+    static DirectMessageEventList createDirectMessageEventList(HttpResponse res, Configuration conf) throws TwitterException {
+        try {
+            if (conf.isJSONStoreEnabled()) {
+                TwitterObjectFactory.clearThreadLocalMap();
+            }
+            JSONObject jsonObject = res.asJSONObject();
+            JSONArray list = jsonObject.getJSONArray("events");
+            int size = list.length();
+            DirectMessageEventList directMessages = new DirectMessageEventListImpl(size, jsonObject, res);
+            for (int i = 0; i < size; i++) {
+                JSONObject json = list.getJSONObject(i);
+                DirectMessageEvent directMessage = new DirectMessageEventJSONImpl(json);
+                directMessages.add(directMessage);
+                if (conf.isJSONStoreEnabled()) {
+                    TwitterObjectFactory.registerJSONObject(directMessage, json);
+                }
+            }
+            if (conf.isJSONStoreEnabled()) {
+                TwitterObjectFactory.registerJSONObject(directMessages, list);
+            }
+            return directMessages;
+        } catch (JSONException jsone) {
+            throw new TwitterException(jsone);
+        }
+    }
+
     @Override
     public int hashCode() {
         return (int) id;

--- a/twitter4j-core/src/internal-json/java/twitter4j/JSONImplFactory.java
+++ b/twitter4j-core/src/internal-json/java/twitter4j/JSONImplFactory.java
@@ -198,6 +198,11 @@ class JSONImplFactory implements ObjectFactory {
     }
 
     @Override
+    public DirectMessageEventList createDirectMessageEventList(HttpResponse res) throws TwitterException {
+        return DirectMessageJSONImpl.createDirectMessageEventList(res, conf);
+    }
+
+    @Override
     public Relationship createRelationship(HttpResponse res) throws TwitterException {
         return new RelationshipJSONImpl(res, conf);
     }

--- a/twitter4j-core/src/internal-json/java/twitter4j/ObjectFactory.java
+++ b/twitter4j-core/src/internal-json/java/twitter4j/ObjectFactory.java
@@ -67,6 +67,8 @@ interface ObjectFactory extends java.io.Serializable {
 
     DirectMessageEvent createDirectMessageEvent(HttpResponse res) throws TwitterException;
 
+    DirectMessageEventList createDirectMessageEventList(HttpResponse res) throws TwitterException;
+
     Relationship createRelationship(HttpResponse res) throws TwitterException;
 
     ResponseList<Friendship> createFriendshipList(HttpResponse res) throws TwitterException;

--- a/twitter4j-core/src/main/java/twitter4j/DirectMessageEvent.java
+++ b/twitter4j-core/src/main/java/twitter4j/DirectMessageEvent.java
@@ -6,7 +6,7 @@ import java.util.Date;
  * @author Hiroaki TAKEUCHI - takke30 at gmail.com
  * @since Twitter4J 4.0.7
  */
-public interface DirectMessageEvent {
+public interface DirectMessageEvent extends TwitterResponse {
 
     String getType();
 

--- a/twitter4j-core/src/main/java/twitter4j/DirectMessageEventList.java
+++ b/twitter4j-core/src/main/java/twitter4j/DirectMessageEventList.java
@@ -1,0 +1,14 @@
+package twitter4j;
+
+/**
+ * List of {@link DirectMessageEvent}
+ *
+ * like string cursor version of {@link PagableResponseList}
+ *
+ * @author Hiroaki TAKEUCHI - takke30 at gmail.com
+ * @since Twitter4J 4.0.7
+ */
+public interface DirectMessageEventList extends ResponseList<DirectMessageEvent> {
+
+    String getNextCursor();
+}

--- a/twitter4j-core/src/main/java/twitter4j/TwitterImpl.java
+++ b/twitter4j-core/src/main/java/twitter4j/TwitterImpl.java
@@ -320,10 +320,15 @@ class TwitterImpl extends TwitterBaseImpl implements Twitter {
     }
 
     @Override
-    public DirectMessage destroyDirectMessage(long id) throws
-        TwitterException {
+    public DirectMessage destroyDirectMessage(long id) throws TwitterException {
         return factory.createDirectMessage(post(conf.getRestBaseURL() + "direct_messages/destroy.json?id=" + id
             + "&full_text=true"));
+    }
+
+    @Override
+    public void destroyDirectMessageEvent(long id) throws TwitterException {
+        ensureAuthorizationEnabled();
+        http.delete(conf.getRestBaseURL() + "direct_messages/events/destroy.json?id=" + id, null, auth, null);
     }
 
     @Override

--- a/twitter4j-core/src/main/java/twitter4j/TwitterImpl.java
+++ b/twitter4j-core/src/main/java/twitter4j/TwitterImpl.java
@@ -302,6 +302,11 @@ class TwitterImpl extends TwitterBaseImpl implements Twitter {
     }
 
     @Override
+    public DirectMessageEvent showDirectMessageEvent(long id) throws TwitterException {
+        return factory.createDirectMessageEvent(get(conf.getRestBaseURL() + "direct_messages/events/show.json?id=" + id));
+    }
+
+    @Override
     public DirectMessage destroyDirectMessage(long id) throws
         TwitterException {
         return factory.createDirectMessage(post(conf.getRestBaseURL() + "direct_messages/destroy.json?id=" + id

--- a/twitter4j-core/src/main/java/twitter4j/TwitterImpl.java
+++ b/twitter4j-core/src/main/java/twitter4j/TwitterImpl.java
@@ -284,6 +284,19 @@ class TwitterImpl extends TwitterBaseImpl implements Twitter {
     }
 
     @Override
+    public DirectMessageEventList getDirectMessageEvents(int count) throws TwitterException {
+        return factory.createDirectMessageEventList(get(conf.getRestBaseURL() + "direct_messages/events/list.json"
+                , new HttpParameter("count", count) ));
+    }
+
+    @Override
+    public DirectMessageEventList getDirectMessageEvents(int count, String cursor) throws TwitterException {
+        return factory.createDirectMessageEventList(get(conf.getRestBaseURL() + "direct_messages/events/list.json"
+                , new HttpParameter("count", count)
+                , new HttpParameter("cursor", cursor)));
+    }
+
+    @Override
     public ResponseList<DirectMessage> getSentDirectMessages() throws TwitterException {
         return factory.createDirectMessageList(get(conf.getRestBaseURL() + "direct_messages/sent.json?full_text=true"));
     }

--- a/twitter4j-core/src/main/java/twitter4j/api/DirectMessagesResources.java
+++ b/twitter4j-core/src/main/java/twitter4j/api/DirectMessagesResources.java
@@ -148,6 +148,18 @@ public interface DirectMessagesResources {
         throws TwitterException;
 
     /**
+     * Deletes the direct message specified in the required ID parameter.
+     * <br>This method calls https://api.twitter.com/1.1/direct_messages/events/destroy.json
+     *
+     * @param The id of the Direct Message event that should be deleted.
+     * @throws TwitterException when Twitter service or network is unavailable
+     * @see <a href="https://developer.twitter.com/en/docs/direct-messages/sending-and-receiving/api-reference/delete-message-event.html" title="DELETE direct_messages/events/destroy — Twitter Developers">DELETE direct_messages/events/destroy — Twitter Developers</a>
+     * @since Twitter4J 4.0.x
+     */
+    void destroyDirectMessageEvent(long id)
+            throws TwitterException;
+
+    /**
      * Sends a new direct message to the specified user from the authenticating user.  Requires both the user and text parameters below.
      * The text will be trimmed if the length of the text is exceeding 140 characters.
      * <br>This method calls https://api.twitter.com/1.1/direct_messages/new

--- a/twitter4j-core/src/main/java/twitter4j/api/DirectMessagesResources.java
+++ b/twitter4j-core/src/main/java/twitter4j/api/DirectMessagesResources.java
@@ -18,6 +18,7 @@ package twitter4j.api;
 
 import twitter4j.DirectMessage;
 import twitter4j.DirectMessageEvent;
+import twitter4j.DirectMessageEventList;
 import twitter4j.MessageData;
 import twitter4j.Paging;
 import twitter4j.ResponseList;
@@ -79,6 +80,31 @@ public interface DirectMessagesResources {
      */
     ResponseList<DirectMessage> getSentDirectMessages(Paging paging)
         throws TwitterException;
+
+    /**
+     * Returns all Direct Message events (both sent and received) within the last 30 days. Sorted in reverse-chronological order.
+     * <br>This method calls https://api.twitter.com/1.1/direct_messages/events/list.json
+     *
+     * @param count Max number of events to be returned. 20 default. 50 max.
+     * @return List
+     * @throws TwitterException when Twitter service or network is unavailable
+     * @see <a href="https://developer.twitter.com/en/docs/direct-messages/sending-and-receiving/api-reference/list-events.html" title="GET direct_messages/events/list — Twitter Developers">GET direct_messages/events/list — Twitter Developers</a>
+     */
+    DirectMessageEventList getDirectMessageEvents(int count)
+            throws TwitterException;
+
+    /**
+     * Returns all Direct Message events (both sent and received) within the last 30 days. Sorted in reverse-chronological order.
+     * <br>This method calls https://api.twitter.com/1.1/direct_messages/events/list.json
+     *
+     * @param count Max number of events to be returned. 20 default. 50 max.
+     * @param cursor For paging through result sets greater than 1 page, use the “next_cursor” property from the previous request.
+     * @return List
+     * @throws TwitterException when Twitter service or network is unavailable
+     * @see <a href="https://developer.twitter.com/en/docs/direct-messages/sending-and-receiving/api-reference/list-events.html" title="GET direct_messages/events/list — Twitter Developers">GET direct_messages/events/list — Twitter Developers</a>
+     */
+    DirectMessageEventList getDirectMessageEvents(int count, String cursor)
+            throws TwitterException;
 
     /**
      * Returns a single direct message, specified by an id parameter.

--- a/twitter4j-core/src/main/java/twitter4j/api/DirectMessagesResources.java
+++ b/twitter4j-core/src/main/java/twitter4j/api/DirectMessagesResources.java
@@ -36,6 +36,7 @@ public interface DirectMessagesResources {
      * @return List
      * @throws TwitterException when Twitter service or network is unavailable
      * @see <a href="https://dev.twitter.com/docs/api/1.1/get/direct_messages">GET direct_messages | Twitter Developers</a>
+     * @deprecated This endpoint will be deprecated and non-functional on June 19, 2018.
      */
     ResponseList<DirectMessage> getDirectMessages()
         throws TwitterException;
@@ -48,6 +49,7 @@ public interface DirectMessagesResources {
      * @return List
      * @throws TwitterException when Twitter service or network is unavailable
      * @see <a href="https://dev.twitter.com/docs/api/1.1/get/direct_messages">GET direct_messages | Twitter Developers</a>
+     * @deprecated This endpoint will be deprecated and non-functional on June 19, 2018.
      */
     ResponseList<DirectMessage> getDirectMessages(Paging paging)
         throws TwitterException;
@@ -59,6 +61,7 @@ public interface DirectMessagesResources {
      * @return List
      * @throws TwitterException when Twitter service or network is unavailable
      * @see <a href="https://dev.twitter.com/docs/api/1.1/get/direct_messages/sent">GET direct_messages/sent | Twitter Developers</a>
+     * @deprecated This endpoint will be deprecated and non-functional on June 19, 2018.
      */
     ResponseList<DirectMessage> getSentDirectMessages()
         throws TwitterException;
@@ -72,6 +75,7 @@ public interface DirectMessagesResources {
      * @throws TwitterException when Twitter service or network is unavailable
      * @see <a href="https://dev.twitter.com/docs/api/1.1/get/direct_messages/sent">GET direct_messages/sent | Twitter Developers</a>
      * @since Twitter4J 2.0.1
+     * @deprecated This endpoint will be deprecated and non-functional on June 19, 2018.
      */
     ResponseList<DirectMessage> getSentDirectMessages(Paging paging)
         throws TwitterException;
@@ -86,6 +90,7 @@ public interface DirectMessagesResources {
      * @throws TwitterException when Twitter service or network is unavailable
      * @see <a href="http://groups.google.com/group/twitter-api-announce/msg/34909da7c399169e">#newtwitter and the API - Twitter API Announcements | Google Group</a>
      * @since Twitter4J 2.1.9
+     * @deprecated This endpoint will be deprecated and non-functional on June 19, 2018.
      */
     DirectMessage showDirectMessage(long id) throws TwitterException;
 
@@ -98,6 +103,7 @@ public interface DirectMessagesResources {
      * @throws TwitterException when Twitter service or network is unavailable
      * @see <a href="https://dev.twitter.com/docs/api/1.1/post/direct_messages/destroy/:id">POST direct_messages/destroy/:id | Twitter Developers</a>
      * @since Twitter4J 2.0.1
+     * @deprecated This endpoint will be deprecated and non-functional on June 19, 2018.
      */
     DirectMessage destroyDirectMessage(long id)
         throws TwitterException;
@@ -127,6 +133,7 @@ public interface DirectMessagesResources {
      * @throws TwitterException when Twitter service or network is unavailable
      * @see <a href="https://dev.twitter.com/docs/api/1.1/post/direct_messages/new">POST direct_messages/new | Twitter Developers</a>
      * @since Twitter4j 2.1.0
+     * @deprecated This endpoint will be deprecated and non-functional on June 19, 2018.
      */
     DirectMessage sendDirectMessage(long userId, String text)
         throws TwitterException;
@@ -141,6 +148,7 @@ public interface DirectMessagesResources {
      * @return DirectMessage
      * @throws TwitterException when Twitter service or network is unavailable
      * @see <a href="https://dev.twitter.com/docs/api/1.1/post/direct_messages/new">POST direct_messages/new | Twitter Developers</a>
+     * @deprecated This endpoint will be deprecated and non-functional on June 19, 2018.
      */
     DirectMessage sendDirectMessage(String screenName, String text)
         throws TwitterException;

--- a/twitter4j-core/src/main/java/twitter4j/api/DirectMessagesResources.java
+++ b/twitter4j-core/src/main/java/twitter4j/api/DirectMessagesResources.java
@@ -95,6 +95,19 @@ public interface DirectMessagesResources {
     DirectMessage showDirectMessage(long id) throws TwitterException;
 
     /**
+     * Returns a single Direct Message event by the given id.
+     * <br>This method has not been finalized and the interface is subject to change in incompatible ways.
+     * <br>This method calls https://api.twitter.com/1.1/direct_messages/events/show.json
+     *
+     * @param id message id
+     * @return DirectMessageEvent
+     * @throws TwitterException when Twitter service or network is unavailable
+     * @see <a href="https://developer.twitter.com/en/docs/direct-messages/sending-and-receiving/api-reference/get-event.html" title="GET direct_messages/events/show — Twitter Developers">GET direct_messages/events/show — Twitter Developers</a>
+     * @since Twitter4J 4.0.x
+     */
+    DirectMessageEvent showDirectMessageEvent(long id) throws TwitterException;
+
+    /**
      * Destroys the direct message specified in the required ID parameter.  The authenticating user must be the recipient of the specified direct message.
      * <br>This method calls https://api.twitter.com/1.1/direct_messages/destroy
      *

--- a/twitter4j-examples/bin/directmessage/destroyDirectMessageEvent.cmd
+++ b/twitter4j-examples/bin/directmessage/destroyDirectMessageEvent.cmd
@@ -1,0 +1,9 @@
+echo off
+SETLOCAL enabledelayedexpansion
+cd ..
+call setEnv.cmd
+
+echo on
+"%JAVA_HOME%\bin\java" %MEM_ARGS% -classpath "%CLASSPATH%" twitter4j.examples.directmessage.DestroyDirectMessageEvent %*
+
+ENDLOCAL

--- a/twitter4j-examples/bin/directmessage/destroyDirectMessageEvent.sh
+++ b/twitter4j-examples/bin/directmessage/destroyDirectMessageEvent.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+cd ..
+. ./setEnv.sh
+
+RUN_CMD="$JAVA_HOME/bin/java $MEM_ARGS -cp $CLASSPATH twitter4j.examples.directmessage.DestroyDirectMessageEvent"
+echo $RUN_CMD ${1+"$@"}
+exec $RUN_CMD ${1+"$@"}

--- a/twitter4j-examples/bin/directmessage/getDirectMessageEvents.cmd
+++ b/twitter4j-examples/bin/directmessage/getDirectMessageEvents.cmd
@@ -1,0 +1,9 @@
+echo off
+SETLOCAL enabledelayedexpansion
+cd ..
+call setEnv.cmd
+
+echo on
+"%JAVA_HOME%\bin\java" %MEM_ARGS% -classpath "%CLASSPATH%" twitter4j.examples.directmessage.GetDirectMessageEvents %*
+
+ENDLOCAL

--- a/twitter4j-examples/bin/directmessage/getDirectMessageEvents.sh
+++ b/twitter4j-examples/bin/directmessage/getDirectMessageEvents.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+cd ..
+. ./setEnv.sh
+RUN_CMD="$JAVA_HOME/bin/java $MEM_ARGS -cp $CLASSPATH twitter4j.examples.directmessage.GetDirectMessageEvents"
+echo $RUN_CMD ${1+"$@"}
+exec $RUN_CMD ${1+"$@"}

--- a/twitter4j-examples/bin/directmessage/showDirectMessageEvent.cmd
+++ b/twitter4j-examples/bin/directmessage/showDirectMessageEvent.cmd
@@ -1,0 +1,9 @@
+echo off
+SETLOCAL enabledelayedexpansion
+cd ..
+call setEnv.cmd
+
+echo on
+"%JAVA_HOME%\bin\java" %MEM_ARGS% -classpath "%CLASSPATH%" twitter4j.examples.directmessage.ShowDirectMessageEvent %*
+
+ENDLOCAL

--- a/twitter4j-examples/bin/directmessage/showDirectMessageEvent.sh
+++ b/twitter4j-examples/bin/directmessage/showDirectMessageEvent.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+cd ..
+. ./setEnv.sh
+RUN_CMD="$JAVA_HOME/bin/java $MEM_ARGS -cp $CLASSPATH twitter4j.examples.directmessage.ShowDirectMessageEvent"
+echo $RUN_CMD ${1+"$@"}
+exec $RUN_CMD ${1+"$@"}

--- a/twitter4j-examples/src/main/java/twitter4j/examples/directmessage/DestroyDirectMessageEvent.java
+++ b/twitter4j-examples/src/main/java/twitter4j/examples/directmessage/DestroyDirectMessageEvent.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2007 Yusuke Yamamoto
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package twitter4j.examples.directmessage;
+
+import twitter4j.Twitter;
+import twitter4j.TwitterException;
+import twitter4j.TwitterFactory;
+
+/**
+ * Destroys specified message.
+ *
+ * @author Hiroaki TAKEUCHI - takke30 at gmail.com
+ */
+public final class DestroyDirectMessageEvent {
+    /**
+     * Usage: java twitter4j.examples.directmessages.DestroyDirectMessageEvent [message id]
+     *
+     * @param args message
+     */
+    public static void main(String[] args) {
+        if (args.length < 1) {
+            System.out.println("Usage: java twitter4j.examples.directmessages.DestroyDirectMessageEvent [message id]");
+            System.exit(-1);
+        }
+        try {
+            Twitter twitter = new TwitterFactory().getInstance();
+            twitter.destroyDirectMessageEvent(Long.parseLong(args[0]));
+            System.out.println("Successfully deleted message [" + args[0] + "].");
+            System.exit(0);
+        } catch (TwitterException te) {
+            te.printStackTrace();
+            System.out.println("Failed to delete message: " + te.getMessage());
+            System.exit(-1);
+        }
+    }
+}

--- a/twitter4j-examples/src/main/java/twitter4j/examples/directmessage/GetDirectMessageEvents.java
+++ b/twitter4j-examples/src/main/java/twitter4j/examples/directmessage/GetDirectMessageEvents.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2007 Yusuke Yamamoto
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package twitter4j.examples.directmessage;
+
+import twitter4j.DirectMessageEvent;
+import twitter4j.DirectMessageEventList;
+import twitter4j.Twitter;
+import twitter4j.TwitterException;
+import twitter4j.TwitterFactory;
+
+/**
+ * Example application that gets all direct messages via event api.<br>
+ *
+ * @author Hiroaki TAKEUCHI - takke30 at gmail.com
+ */
+public class GetDirectMessageEvents {
+    /**
+     * Usage: java twitter4j.examples.directmessage.GetDirectMessageEvents
+     *
+     * @param args String[]
+     */
+    public static void main(String[] args) {
+        Twitter twitter = new TwitterFactory().getInstance();
+        try {
+            String cursor = null;
+            int count = 20;
+            DirectMessageEventList messages;
+            do {
+                System.out.println("* cursor:" + cursor);
+                messages = cursor == null ? twitter.getDirectMessageEvents(count) : twitter.getDirectMessageEvents(count, cursor);
+                for (DirectMessageEvent message : messages) {
+                    System.out.println("From: " + message.getSenderId() + " id:" + message.getId()
+                            + " [" + message.getCreatedTimestamp() + "]"
+                            + " - " + message.getText());
+                    System.out.println("raw[" + message + "]");
+                }
+                cursor = messages.getNextCursor();
+            } while (messages.size() > 0 && cursor != null);
+            System.out.println("done.");
+            System.exit(0);
+        } catch (TwitterException te) {
+            te.printStackTrace();
+            System.out.println("Failed to get messages: " + te.getMessage());
+            System.exit(-1);
+        }
+    }
+}

--- a/twitter4j-examples/src/main/java/twitter4j/examples/directmessage/ShowDirectMessageEvent.java
+++ b/twitter4j-examples/src/main/java/twitter4j/examples/directmessage/ShowDirectMessageEvent.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2007 Yusuke Yamamoto
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package twitter4j.examples.directmessage;
+
+import twitter4j.DirectMessageEvent;
+import twitter4j.Twitter;
+import twitter4j.TwitterException;
+import twitter4j.TwitterFactory;
+
+/**
+ * Example application that gets a specified direct message via event api.<br>
+ *
+ * @author Hiroaki TAKEUCHI - takke30 at gmail.com
+ */
+public class ShowDirectMessageEvent {
+    /**
+     * Usage: java twitter4j.examples.directmessage.ShowDirectMessageEvent [message id]
+     *
+     * @param args String[]
+     */
+    public static void main(String[] args) {
+        if (args.length < 1) {
+            System.out.println("Usage: java twitter4j.examples.directmessage.ShowDirectMessageEvent [message id]");
+            System.exit(-1);
+        }
+        Twitter twitter = new TwitterFactory().getInstance();
+        try {
+            DirectMessageEvent message = twitter.showDirectMessageEvent(Long.parseLong(args[0]));
+            System.out.println("From: @" + message.getSenderId() + " id:" + message.getId() + " - " + message.getText());
+            System.exit(0);
+        } catch (TwitterException te) {
+            te.printStackTrace();
+            System.out.println("Failed to get message: " + te.getMessage());
+            System.exit(-1);
+        }
+    }
+}


### PR DESCRIPTION
- mark deprecated to old direct message methods
- add Twitter.showDirectMessageEvent (support https://api.twitter.com/1.1/direct_messages/events/show.json)
- add Twitter.getDirectMessageEvents (support https://api.twitter.com/1.1/direct_messages/events/list.json)
- add Twitter.destroyDirectMessageEvent (support https://api.twitter.com/1.1/direct_messages/events/destroy.json)

see https://developer.twitter.com/en/docs/direct-messages/sending-and-receiving/api-reference
